### PR TITLE
Update preparation blocks

### DIFF
--- a/src/sequences/preparations/t1_inv_prep.py
+++ b/src/sequences/preparations/t1_inv_prep.py
@@ -45,6 +45,7 @@ def add_t1_inv_prep(
     if system is None:
         system = sys_defaults
 
+    # create new sequence if not provided
     if seq is None:
         seq = pp.Sequence(system=system)
 
@@ -57,18 +58,18 @@ def add_t1_inv_prep(
         adiabaticity=6,
         beta=800,
         mu=4.9,
-        delay=system.rf_dead_time,
+        delay=system.rf_dead_time,  # type: ignore
         duration=rf_duration,
         system=system,
         use='inversion',
     )
-    seq.add_block(rf)
+    seq.add_block(rf)  # type: ignore
 
     # Add spoiler gradient if requested
     if add_spoiler:
         gz_spoil = pp.make_trapezoid(
             channel='z',
-            amplitude=0.4 * system.max_grad,
+            amplitude=0.4 * system.max_grad,  # type: ignore
             flat_time=spoiler_flat_time,
             rise_time=spoiler_ramp_time,
             system=system,
@@ -79,6 +80,6 @@ def add_t1_inv_prep(
     block_duration = sum(seq.block_durations.values()) - time_start
 
     # calculate time passed since point of inversion (=middle of inversion pulse)
-    time_since_inversion = block_duration - system.rf_dead_time - rf_duration / 2
+    time_since_inversion = block_duration - system.rf_dead_time - rf_duration / 2  # type: ignore
 
     return (seq, block_duration, time_since_inversion)

--- a/tests/preparations/test_t2_prep.py
+++ b/tests/preparations/test_t2_prep.py
@@ -8,50 +8,20 @@ from sequences.preparations.t2_prep import add_composite_refocusing_block
 from sequences.preparations.t2_prep import add_t2_prep
 
 
-def test_add_composite_refocusing_block_raise_error_no_rf_dead_time(system_defaults):
-    """Test if a ValueError is raised if rf_dead_time is not set."""
-    system_defaults.rf_dead_time = None
-
-    seq = pp.Sequence(system=system_defaults)
-    with pytest.raises(ValueError, match='rf_dead_time must be provided'):
-        add_composite_refocusing_block(seq=seq, system=system_defaults, duration_180=2e-3)
-
-
 @pytest.mark.parametrize(
-    ('duration_180', 'rf_dead_time'),
-    [(2e-3, 100e-6), (2e-3, 200e-6), (4e-3, 100e-6), (6e-3, 200e-6)],
+    ('duration_180', 'rf_dead_time', 'rf_ringdown_time'),
+    [(2e-3, 100e-6, 30e-6), (2e-3, 200e-6, 30e-6), (4e-3, 100e-6, 30e-6), (2e-3, 100e-6, 60e-6)],
 )
-def test_add_composite_refocusing_block_duration(system_defaults, duration_180, rf_dead_time):
+def test_add_composite_refocusing_block_duration(system_defaults, duration_180, rf_dead_time, rf_ringdown_time):
     """Ensure the default parameters are set correctly."""
     system_defaults.rf_dead_time = rf_dead_time
+    system_defaults.rf_ringdown_time = rf_ringdown_time
     seq = pp.Sequence(system=system_defaults)
 
     seq, total_dur, _ = add_composite_refocusing_block(seq=seq, system=system_defaults, duration_180=duration_180)
 
     assert total_dur == sum(seq.block_durations.values())
-    assert total_dur == pytest.approx(2 * duration_180 + 3 * rf_dead_time)
-
-
-@pytest.mark.parametrize('rf_ringdown_time', [0, 30e-6, 100e-6, 1])
-def test_add_composite_refocusing_block_no_ringdown_dependency(system_defaults, rf_ringdown_time):
-    """Test if the block duration is not dependent on the ringdown time."""
-    system1 = system_defaults
-    system2 = deepcopy(system1)
-    system2.rf_ringdown_time = rf_ringdown_time
-
-    seq = pp.Sequence(system=system_defaults)
-
-    _, total_dur1, _ = add_composite_refocusing_block(seq=seq, system=system1, duration_180=2e-3)
-    _, total_dur2, _ = add_composite_refocusing_block(seq=seq, system=system2, duration_180=2e-3)
-
-    assert total_dur1 == total_dur2
-
-
-def test_add_t2_prep_raise_error_no_rf_dead_time(system_defaults):
-    """Test if a ValueError is raised if rf_dead_time is not set."""
-    system_defaults.rf_dead_time = None
-    with pytest.raises(ValueError, match='rf_dead_time must be provided'):
-        add_t2_prep(system=system_defaults)
+    assert total_dur == pytest.approx(2 * duration_180 + 3 * rf_dead_time + 3 * rf_ringdown_time)
 
 
 @pytest.mark.parametrize(('echo_time', 'duration_180'), [(0.01, 1e-3), (0.011, 1e-3), (0.015, 1e-3), (0.04, 4e-3)])
@@ -102,8 +72,10 @@ def test_add_t2_prep_duration(
         + duration_180 / 4  # half duration of 90° excitation pulse
         + echo_time  # echo time
         + duration_180 / 2 * 3 / 2  # half duration of 270° pulse
+        + system_defaults.rf_ringdown_time  # ringdown time after 270° pulse
         + system_defaults.rf_dead_time  # dead time before 360° pulse
         + duration_180 * 2  # duration of 360° pulse
+        + system_defaults.rf_ringdown_time  # ringdown time after 360° pulse
     )
     if add_spoiler:
         manual_time_calc += 2 * spoiler_ramp_time + spoiler_flat_time


### PR DESCRIPTION
I removed the overwriting of the rf ringdown time in the preparation blocks because this was causing errors in the timing check of the final sequence after adding a preparation block. 

It's still possible to enforce `rf_ringdown_time = 0` by choosing it as general system setting for the whole sequence. However, this should be done with care!!!

The total sequence timings of the reference sequences did not change, because the additional ringdown times are automatically considered in the delays. But maybe double check this as well @ckolbPTB 